### PR TITLE
Mixins: Allow mixing in to non-Minecraft classes

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/DynamicMixinManager.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/DynamicMixinManager.kt
@@ -9,6 +9,7 @@ import com.chattriggers.ctjs.internal.launch.generation.GenerationContext
 import com.chattriggers.ctjs.internal.launch.generation.Utils
 import kotlinx.serialization.json.*
 import org.spongepowered.asm.mixin.Mixins
+import org.spongepowered.asm.service.MixinService
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.net.URL
@@ -28,7 +29,14 @@ internal object DynamicMixinManager {
 
     fun applyAccessWideners() {
         for ((mixin, details) in mixins) {
-            val mappedClass = Mappings.getMappedClass(mixin.target) ?: error("Unknown class name ${mixin.target}")
+            val mappedClass = Mappings.getMappedClass(mixin.target) ?: run {
+                if (mixin.remap == false) {
+                    Mappings.getUnmappedClass(mixin.target)
+                } else {
+                    error("Unknown class name ${mixin.target}")
+                }
+            }
+
             for ((field, isMutable) in details.fieldWideners)
                 Utils.widenField(mappedClass, field, isMutable)
             for ((method, isMutable) in details.methodWideners)

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/GenerationContext.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/GenerationContext.kt
@@ -7,7 +7,13 @@ import com.chattriggers.ctjs.internal.launch.Mixin
 import org.spongepowered.asm.mixin.transformer.ClassInfo
 
 internal data class GenerationContext(val mixin: Mixin) {
-    val mappedClass = Mappings.getMappedClass(mixin.target) ?: error("Unknown class name ${mixin.target}")
+    val mappedClass = Mappings.getMappedClass(mixin.target) ?: run {
+        if (mixin.remap == false) {
+            Mappings.getUnmappedClass(mixin.target)
+        } else {
+            error("Unknown class name ${mixin.target}")
+        }
+    }
     val generatedClassName = "CTMixin_\$${mixin.target.replace('.', '_')}\$_${mixinCounter++}"
     val generatedClassFullPath = "${DynamicMixinManager.GENERATED_PACKAGE}/$generatedClassName"
 


### PR DESCRIPTION
This works for injection points, but doesn't work for access wideners, as it could potentially lead to problems (normal Fabric access wideners don't support non-Minecraft classes).